### PR TITLE
Update npm auth token

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-//npm.pkg.github.com/:_authToken=c9f70f5dafd6ca496520e6379efacd89b3330400
+//npm.pkg.github.com/:_authToken=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
 @untile:registry=https://npm.pkg.github.com


### PR DESCRIPTION
This PR updates the `.npmrc` auth token because the current has expired.  
We cannot remove the `.npmrc` from this repo because it is deployed to `fleek.io`.