### PR TITLE
Update validate-branch-name pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "yarn": ">=1.22.0"
   },
   "validate-branch-name": {
-    "pattern": "^(bugfix|enhancement|feature|hotfix|support)/.+$",
-    "errorMsg": "Only the following prefixes are allowed: bugfix|enhancement|feature|hotfix|support"
+    "pattern": "^(bugfix|development|enhancement|feature|hotfix|master|support)/.+$",
+    "errorMsg": "Only the following prefixes are allowed: bugfix|development|enhancement|feature|hotfix|master|support"
   }
 }


### PR DESCRIPTION
This PR updates the validate-branch-name pattern to allow `development` and `master` because releases that push for both branches.